### PR TITLE
Corrected logic for active projects code. 

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -200,11 +200,11 @@ function generateBarchartDataset (jsonview, cmpDate) {
             continue;
         }
         if((closeDate != "0000-00-00") && (closeDate < cmpDateStr)) { // closed projects
-            console.log(cmpDateStr + " Skipping closed: " + k[1] + " " + closeDate);
+            // console.log(cmpDateStr + " Skipping closed: " + k[1] + " " + closeDate);
             continue;
         }
         if ((arrivalDate > cmpDateStr) || (arrivalDate == "0000-00-00") ) { // proj w arrival date after cmp date
-            console.log(cmpDateStr + " Skipping " + arrivalDate);
+            //console.log(cmpDateStr + " Skipping " + arrivalDate);
             continue;
         } 
         if ( (queueDate == "0000-00-00") || cmpDateStr < queueDate) { 


### PR DESCRIPTION
This includes additions to the KPI and KPI_application map functions in statusdb to also emit "Close date". 
Already closed projects are now excluded from active projects.
Also, ongoing projects without queue date but with libQC date are now counted as being in sequencing.

The number of active projects in different process steps should now be correct. 
