### PR TITLE
Bug fix for seq load calculation for finlib projects

### DIFF
--- a/stack.js
+++ b/stack.js
@@ -507,7 +507,6 @@ function generateSeqLoadDataset(json, cmpDate) {
             stepStartDate = seqStartDate;
         }
         
-        //if (libQCDate != "0000-00-00" &&
         if (stepStartDate != "0000-00-00" &&
             libQCDate <= cmpDateStr &&
             seqDoneDate == "0000-00-00") {


### PR DESCRIPTION
Finished library lanes load would show up in both queue and ongoing load. Now corrected.
