### PR TITLE
fixed relocate to be generic

### DIFF
--- a/Application/index.php
+++ b/Application/index.php
@@ -1,6 +1,10 @@
 <?php
-$appname=explode('/', $_SERVER['REQUEST_URI']);
-$location="http://".$_SERVER['HTTP_HOST']."/".$appname[1]."/dashboard_all.php?ptype=Application";
+if($_SERVER['REQUEST_URI']!='/Application/'){
+    $appname=explode('/', $_SERVER['REQUEST_URI']);
+    $location="http://".$_SERVER['HTTP_HOST']."/".$appname[1]."/dashboard_all.php?ptype=Application";
+}else{
+    $location="http://".$_SERVER['HTTP_HOST']."/dashboard_all.php?ptype=Application";
+}
 header("Location: ".$location);
 
 ?>


### PR DESCRIPTION
the /Application link should now be working, and should work while being independant of the base name.
